### PR TITLE
Readme changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ Note: Query arguments are stripped for matching purposes.
 
 Any of the Docker endpoints can be matched - so for example the following routes are perfectly valid:
 
-* ``POST /*/containers/*/create``
+* ``POST /*/containers/create``
 * ``POST /*/containers/*/start``
 * ``POST /*/containers/*/stop``
 * ``POST /*/containers/*/kill``


### PR DESCRIPTION
There are a couple of changes to the Readme in the PR:
##### highlight that any endpoint can be matched

For a moment I was under the impression that only the /containers/create endpoint could be used as all of the examples use it.

I've added a note making it clear that ALL routes can be matched in the config and added an extra part to the `Defining Endpoints` section that give examples of /start, /stop and /kill routes.
##### plugin ideas

As a `and finally` inspiration for readers to get hacking - I've added a section for some cool plugins that could be written - hopefully this will grow into a useful list!
##### fixes
- for the example in the `Goal of project` section - the `weave` plugin was pointing to the `flocker` endpoint 
