### PR TITLE
Fix content length

### DIFF
--- a/powerstrip/powerstrip.py
+++ b/powerstrip/powerstrip.py
@@ -308,14 +308,17 @@ class DockerProxy(proxy.ReverseProxyResource):
             d.addCallback(callPostHook, hookURL=hookURL)
             d.addCallback(treq.json_content)
         def sendFinalResponseToClient(result):
+            """
             resultBody = result["ModifiedServerResponse"]["Body"].encode("utf-8")
             # Update the Content-Length, since we're modifying the request object in-place.
             request.responseHeaders.setRawHeaders(
                 b"content-length",
                 [str(len(resultBody))]
             )
+            """
             # Write the final response to the client.
-            request.write(resultBody)
+            # request.write(resultBody)
+            request.write(result["ModifiedServerResponse"]["Body"].encode("utf-8"))
             request.finish()
         d.addCallback(sendFinalResponseToClient)
         def squashNoPostHooks(failure):

--- a/powerstrip/powerstrip.py
+++ b/powerstrip/powerstrip.py
@@ -307,18 +307,15 @@ class DockerProxy(proxy.ReverseProxyResource):
             hookURL = self.config.adapter_uri(postHook)
             d.addCallback(callPostHook, hookURL=hookURL)
             d.addCallback(treq.json_content)
-        def sendFinalResponseToClient(result):
-            """
+        def sendFinalResponseToClient(result):            
             resultBody = result["ModifiedServerResponse"]["Body"].encode("utf-8")
             # Update the Content-Length, since we're modifying the request object in-place.
             request.responseHeaders.setRawHeaders(
                 b"content-length",
                 [str(len(resultBody))]
             )
-            """
             # Write the final response to the client.
-            # request.write(resultBody)
-            request.write(result["ModifiedServerResponse"]["Body"].encode("utf-8"))
+            request.write(resultBody)
             request.finish()
         d.addCallback(sendFinalResponseToClient)
         def squashNoPostHooks(failure):

--- a/powerstrip/powerstrip.py
+++ b/powerstrip/powerstrip.py
@@ -308,8 +308,14 @@ class DockerProxy(proxy.ReverseProxyResource):
             d.addCallback(callPostHook, hookURL=hookURL)
             d.addCallback(treq.json_content)
         def sendFinalResponseToClient(result):
+            resultBody = result["ModifiedServerResponse"]["Body"].encode("utf-8")
+            # Update the Content-Length, since we're modifying the request object in-place.
+            request.responseHeaders.setRawHeaders(
+                b"content-length",
+                [str(len(resultBody))]
+            )
             # Write the final response to the client.
-            request.write(result["ModifiedServerResponse"]["Body"].encode("utf-8"))
+            request.write(resultBody)
             request.finish()
         d.addCallback(sendFinalResponseToClient)
         def squashNoPostHooks(failure):

--- a/powerstrip/test/test_core.py
+++ b/powerstrip/test/test_core.py
@@ -203,6 +203,23 @@ adapters:
         d.addCallback(verify)
         return d
 
+    def test_content_length_post_hook(self):
+        """
+        When the content length is changed by a post-hook, test that powerstrip returns the
+        correct content as per the content-length
+        """
+        d = self._hookTest("""endpoints:
+  "POST %(dockerEndpoint)s":
+    pre: []
+    post: [adder,adder,adder,adder,adder,adder,adder,adder,adder,adder]
+adapters:
+  adder: http://127.0.0.1:%(adderPort)d%(adapterEndpoint)s""", adderArgs=dict(post=True))
+        def verify(response):
+            self.assertEqual(response,
+                    {"Number": 10, "SeenByFakeDocker": 42})
+        d.addCallback(verify)
+        return d
+
     def test_adding_post_hook_twice_adapter(self):
         """
         Chaining post-hooks: adding twice means you get +2.

--- a/powerstrip/test/test_core.py
+++ b/powerstrip/test/test_core.py
@@ -211,7 +211,7 @@ adapters:
         d = self._hookTest("""endpoints:
   "POST %(dockerEndpoint)s":
     pre: []
-    post: [adder,adder,adder,adder,adder,adder,adder,adder,adder,adder]
+    post: [adder,adder,adder,adder,adder,adder,adder,adder,adder]
 adapters:
   adder: http://127.0.0.1:%(adderPort)d%(adapterEndpoint)s""", adderArgs=dict(post=True))
         def verify(response):


### PR DESCRIPTION
This is a version of PR #63 but with commits with a failing and then passing test

-------------------------------

If a post-hook updated the request body, the Content-Length was
not being updated in some situations.

Explicitly update the Content-Length to guard against this
scenario.

Fixes #61