### PR TITLE
Implemented connection fail solver and updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN         apt-get -qy update
 RUN         apt-get -qy upgrade
 RUN         apt-get -qy install python-pip
 RUN         apt-get -qy install python-dev
-RUN         apt-get -qy install python-pyasn1
+RUN         pip install pyasn1
 RUN         apt-get -qy install libyaml-dev
 RUN         apt-get -qy install libffi-dev
 RUN         apt-get -qy install libssl-dev

--- a/powerstrip/powerstrip.py
+++ b/powerstrip/powerstrip.py
@@ -154,6 +154,9 @@ class DockerProxyClientFactory(proxy.ProxyClientFactory):
         self._fireListener(client)
         return client
 
+    def clientConnectionFailed(self, connector, reason):
+       connector.connect()
+
 
 
 class DockerProxy(proxy.ReverseProxyResource):


### PR DESCRIPTION
I was having some troubles with powerstrip where if a request was dropped powerstrip didn't retried again. I add a simple method to retry it.
While I was building the docker image I saw some dependencies conflicts and that's why I had to change the `pyasn1` installation source.

Signed-off-by: André Martins <aanm90@gmail.com>